### PR TITLE
Switch to bifurcan for collection

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,6 +46,12 @@
     </dependency>
 
     <dependency>
+      <groupId>io.lacuna</groupId>
+      <artifactId>bifurcan</artifactId>
+      <version>0.1.0</version>
+    </dependency>
+
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <version>4.11</version>

--- a/src/main/java/io/github/espresso4j/espresso/ExtensionHolder.java
+++ b/src/main/java/io/github/espresso4j/espresso/ExtensionHolder.java
@@ -1,9 +1,10 @@
 package io.github.espresso4j.espresso;
 
+import io.lacuna.bifurcan.IMap;
+import io.lacuna.bifurcan.LinearMap;
+
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import java.util.HashMap;
-import java.util.Map;
 
 /**
  * Holds some extension that middlewares write into.
@@ -12,7 +13,7 @@ import java.util.Map;
  */
 public class ExtensionHolder {
 
-    Map<Class<?>, Object> extensions = new HashMap<>();
+    IMap<Class<?>, Object> extensions = new LinearMap<>();
 
     /**
      * Get the stored extensions
@@ -20,7 +21,7 @@ public class ExtensionHolder {
      * @return the map of extensions
      */
     @Nonnull
-    public Map<Class<?>, Object> extensions() {
+    public IMap<Class<?>, Object> extensions() {
         return this.extensions;
     }
 

--- a/src/main/java/io/github/espresso4j/espresso/Request.java
+++ b/src/main/java/io/github/espresso4j/espresso/Request.java
@@ -1,10 +1,12 @@
 package io.github.espresso4j.espresso;
 
+import io.lacuna.bifurcan.IMap;
+import io.lacuna.bifurcan.LinearMap;
+
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.io.InputStream;
 import java.security.cert.X509Certificate;
-import java.util.HashMap;
 import java.util.Map;
 
 /**
@@ -30,7 +32,7 @@ public class Request extends ExtensionHolder {
 
     private X509Certificate sslClientCert;
 
-    private Map<String, String> headers = new HashMap<>();
+    private IMap<String, String> headers = new LinearMap<>();
 
     private InputStream body;
 
@@ -211,7 +213,7 @@ public class Request extends ExtensionHolder {
      * @return the header map
      */
     @Nonnull
-    public Map<String, String> getHeaders() {
+    public IMap<String, String> getHeaders() {
         return headers;
     }
 
@@ -221,7 +223,7 @@ public class Request extends ExtensionHolder {
      * @param headers the header map
      */
     public void setHeaders(@Nonnull Map<String, String> headers) {
-        this.headers = headers;
+        headers.forEach(this.headers::put);
     }
 
     /**

--- a/src/main/java/io/github/espresso4j/espresso/Response.java
+++ b/src/main/java/io/github/espresso4j/espresso/Response.java
@@ -1,10 +1,11 @@
 package io.github.espresso4j.espresso;
 
+import io.lacuna.bifurcan.IMap;
+import io.lacuna.bifurcan.LinearMap;
+
 import java.io.File;
 import java.io.InputStream;
-import java.util.HashMap;
 import java.util.Iterator;
-import java.util.Map;
 
 /**
  * The HTTP response object.
@@ -17,11 +18,9 @@ public class Response extends ExtensionHolder {
 
     private Integer status = 200;
 
-    private Map<String, String> headers = new HashMap<>();
+    private IMap<String, String> headers = new LinearMap<>();
 
     private IntoBody body;
-
-    private Map<Class<?>, Object> extensions = new HashMap<>();
 
     /**
      * Get to status code stored in this response
@@ -48,7 +47,7 @@ public class Response extends ExtensionHolder {
      *
      * @return map of headers
      */
-    public Map<String, String> headers() {
+    public IMap<String, String> headers() {
         return headers;
     }
 
@@ -146,7 +145,6 @@ public class Response extends ExtensionHolder {
                 "status=" + status +
                 ", headers=" + headers +
                 ", body=" + body +
-                ", extensions=" + extensions +
-                '}';
+                "} " + super.toString();
     }
 }


### PR DESCRIPTION
Fixes #4 

This patch switches internal data structure to bifurcan. It also changes some interfaces from `java.util.Map` to bifurcan's `IMap`, which is a break change.